### PR TITLE
Load all layers

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -482,6 +482,13 @@ function LDtk.get_empty_tileIDs( level_name, tileset_enum_value, layer_name )
 	return tileset.tileIDs_empty[ tileset_enum_value ]
 end
 
+-- return all layers from a level
+function LDtk.get_layers(level_name)
+	local level = _levels[level_name]
+
+	if not level then return end
+	return level.layers
+end
 
 --
 -- internal functions

--- a/LDtk.lua
+++ b/LDtk.lua
@@ -269,7 +269,7 @@ function LDtk.load_level( level_name )
 		local layer_type = layer_data.__type
 
 		layer.grid_size = layer_data.__gridSize
-		layer.zIndex = layer_index
+		layer.zIndex = _.flipZIndex(layer_index)
 		layer.rect = {
 			x = level_data.worldX + layer_data.__pxTotalOffsetX,
 			y = level_data.worldY + layer_data.__pxTotalOffsetY,
@@ -358,7 +358,7 @@ function LDtk.load_level( level_name )
 					position = { x=entity_data.px[1], y=entity_data.px[2] },
 					center = { x=entity_data.__pivot[1], y=entity_data.__pivot[2] },
 					size = { width=entity_data.width, height=entity_data.height },
-					zIndex = layer_index,
+					zIndex = _.flipZIndex(layer_index),
 					fields = properties,
 				})
 			end
@@ -585,6 +585,11 @@ function _.get_tile_layer( level_name, layer_name )
 			return layer
 		end
 	end
+end
+
+-- revert the ZIndex so that it's useable in Playdate SDK context
+function _.flipZIndex(layerZIndex)
+    return 1000 - layerZIndex
 end
 
 -- write the content of a table in a lua file

--- a/LDtk.lua
+++ b/LDtk.lua
@@ -261,6 +261,7 @@ function LDtk.load_level( level_name )
 
 	-- handle layers
 	level.layers = {}
+	local layer_count = #level_data.layerInstances
 	for layer_index, layer_data in ipairs(level_data.layerInstances) do
 
 		local layer = {}
@@ -269,7 +270,7 @@ function LDtk.load_level( level_name )
 		local layer_type = layer_data.__type
 
 		layer.grid_size = layer_data.__gridSize
-		layer.zIndex = _.flipZIndex(layer_index)
+		layer.zIndex = layer_count - layer_index
 		layer.rect = {
 			x = level_data.worldX + layer_data.__pxTotalOffsetX,
 			y = level_data.worldY + layer_data.__pxTotalOffsetY,
@@ -358,7 +359,7 @@ function LDtk.load_level( level_name )
 					position = { x=entity_data.px[1], y=entity_data.px[2] },
 					center = { x=entity_data.__pivot[1], y=entity_data.__pivot[2] },
 					size = { width=entity_data.width, height=entity_data.height },
-					zIndex = _.flipZIndex(layer_index),
+					zIndex = layer.zIndex,
 					fields = properties,
 				})
 			end
@@ -585,11 +586,6 @@ function _.get_tile_layer( level_name, layer_name )
 			return layer
 		end
 	end
-end
-
--- revert the ZIndex so that it's useable in Playdate SDK context
-function _.flipZIndex(layerZIndex)
-    return 1000 - layerZIndex
 end
 
 -- write the content of a table in a lua file

--- a/code/game.lua
+++ b/code/game.lua
@@ -1,5 +1,6 @@
 game = {}
 
+local layerSprites = {}
 local _background_sprite = playdate.graphics.sprite.new()
 
 function game.init( level_name )
@@ -18,15 +19,30 @@ function goto_level( level_name, direction )
 	LDtk.release_level( previous_level )
 	playdate.graphics.sprite.removeAll()
 
-	game.tilemap = LDtk.create_tilemap( level_name ) 
+	layerSprites = {}
+	for index, layer in pairs(LDtk.get_layers(level_name)) do
+		if not layer.tiles then
+			goto continue
+		end
 
-	_background_sprite:setTilemap( game.tilemap )
-	_background_sprite:moveTo( 0, 0)
-	_background_sprite:setCenter(0, 0)
-	_background_sprite:setZIndex( -1 )
-	_background_sprite:add()
+		local tilemap = LDtk.create_tilemap(level_name, index)
 
-	playdate.graphics.sprite.addWallSprites( game.tilemap, LDtk.get_empty_tileIDs( level_name, "Solid") )
+		local layerSprite = playdate.graphics.sprite.new()
+		layerSprite:setTilemap(tilemap)
+		layerSprite:moveTo(0, 0)
+		layerSprite:setCenter(0, 0)
+		layerSprite:setZIndex(layer.zIndex)
+		layerSprite:add()
+		layerSprites[index] = layerSprite
+
+		local emptyTiles = LDtk.get_empty_tileIDs(level_name, "Solid", index)
+
+		if emptyTiles then
+			playdate.graphics.sprite.addWallSprites(tilemap, emptyTiles)
+		end
+
+		::continue::
+	end
 
 	for index, entity in ipairs( LDtk.get_entities( level_name ) ) do
 		if entity.name=="Player" then
@@ -37,12 +53,16 @@ function goto_level( level_name, direction )
 		end
 	end
 
-
+	
 	playdate.graphics.sprite.setAlwaysRedraw(true)
 end
 
 function game.shutdown()
-	_background_sprite:remove()
+	for index in pairs(LDtk.get_layers(game.level_name)) do
+        layerSprites[index]:remove()
+        layerSprites[index] = nil
+    end
+
 	LDtk.release_level( game.level_name )
 end
 

--- a/code/game.lua
+++ b/code/game.lua
@@ -20,12 +20,12 @@ function goto_level( level_name, direction )
 	playdate.graphics.sprite.removeAll()
 
 	layerSprites = {}
-	for index, layer in pairs(LDtk.get_layers(level_name)) do
+	for layer_name, layer in pairs(LDtk.get_layers(level_name)) do
 		if not layer.tiles then
 			goto continue
 		end
 
-		local tilemap = LDtk.create_tilemap(level_name, index)
+		local tilemap = LDtk.create_tilemap(level_name, layer_name)
 
 		local layerSprite = playdate.graphics.sprite.new()
 		layerSprite:setTilemap(tilemap)
@@ -33,9 +33,9 @@ function goto_level( level_name, direction )
 		layerSprite:setCenter(0, 0)
 		layerSprite:setZIndex(layer.zIndex)
 		layerSprite:add()
-		layerSprites[index] = layerSprite
+		layerSprites[layer_name] = layerSprite
 
-		local emptyTiles = LDtk.get_empty_tileIDs(level_name, "Solid", index)
+		local emptyTiles = LDtk.get_empty_tileIDs(level_name, "Solid", layer_name)
 
 		if emptyTiles then
 			playdate.graphics.sprite.addWallSprites(tilemap, emptyTiles)
@@ -58,9 +58,9 @@ function goto_level( level_name, direction )
 end
 
 function game.shutdown()
-	for index in pairs(LDtk.get_layers(game.level_name)) do
-        layerSprites[index]:remove()
-        layerSprites[index] = nil
+	for layer_name in pairs(LDtk.get_layers(game.level_name)) do
+        layerSprites[layer_name]:remove()
+        layerSprites[layer_name] = nil
     end
 
 	LDtk.release_level( game.level_name )


### PR DESCRIPTION
This PR makes sure it's not only loading the first layer, but all layers.
It also fixes some issues:

- When moving between rooms, backgroundImage kept which caused some issues.
- Reordering layers in LDtk was not taken into account in the importer. ZIndexes are now retrieved from LDtk and flipped to be useable. 
- Stops automatically adding collision when "tileEnum" is not added to a layer