### PR TITLE
Fix broken neighbour code from LDtk version 1.2 removing level Uid

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -176,7 +176,7 @@ function LDtk.load( ldtk_file, use_lua_levels )
 
 	-- we list the level names (the complete list needs to be ready before calling LDtk.load_level())
 	for level_index, level_data in ipairs(data.levels) do
-		_level_names[ level_data.uid ] = level_data.identifier
+		_level_names[ level_data.iid ] = level_data.identifier
 		_level_rects[ level_data.identifier ] = { x=level_data.worldX, y=level_data.worldY, width=level_data.pxWid, height=level_data.pxHei }
 	end
 
@@ -255,7 +255,7 @@ function LDtk.load_level( level_name )
 	for index, neighbour_data in ipairs(level_data.__neighbours) do
 		local direction = direction_table[ neighbour_data.dir ]
 		if direction then
-			table.insert( level.neighbours[ direction ], _level_names[ neighbour_data.levelUid ])
+			table.insert( level.neighbours[ direction ], _level_names[ neighbour_data.levelIid ])
 		end
 	end
 


### PR DESCRIPTION
## Summary
LDtk has recently been updated to version 1.2. Changes to the JSON format were made which broke the neighbour data part of the importer (i.e. requesting neighbouring levels would always return nil as neighbours were not being properly saved). 

JSON change from the release notes:
```Removed NeighbourLevel.levelUid (use levelIid instead)```

The fix is to use ```levelIid``` instead of ```levelUid```. 

## Notes
Change doesn't include an updated world.ldtk, so these changes will break on the current version 0.9.3 world.ldtk file until it's updated.

## Testing
- Tested on example world.ldtk by opening the ldtk file, saving it in version 1.2, rebuilding the PDX, and testing if moving between neighbouring levels worked correctly
- Tested on my game "The King's Dungeon" with 35 different neighbouring levels and confirming neighbouring levels worked correctly