### PR TITLE
Tileset_uid exported improperly as string instead of number, causing get_tileIDs/get_empty_tileIDs to fail when using precomputed levels

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -623,7 +623,11 @@ function _.export_lua_table( filepath, table_to_export )
 				end
 			else
 				for key, value in pairs(entry) do
-					file:write("[\""..tostring(key).."\"]=")
+					if type(key) == "number" then
+						file:write("["..tostring(key).."]=")
+					else
+						file:write("[\""..tostring(key).."\"]=")
+					end
 					_write_entry(value, key)
 					file:write(",")
 				end


### PR DESCRIPTION
## Issue
The `_.export_lua_table` function saves the `_tilesets` table incorrectly in some circumstances. This circumstance is when `__tilesetDefUid` is not sequential. 

This is a minimum reproduction of an example of a .ldtk file with 1 entity layer and a subsequent int grid layer. There is only one non-null `__tilesetDefUid` and it's set to 2. [test.zip](https://github.com/NicMagnier/PlaydateLDtkImporter/files/10454523/test.zip)

This makes it so that the keys to `_tilesets` are saved as strings, as the `_isArray` function correctly outputs that it is not an array, but the `tileset_uid` retrieved from `__tilesetDefUid` are still numbers, which causes the lookup in `get_tileIDs` and `get_empty_tileIDs` (`_tilesets[ layer.tileset_uid ]`) to fail when using a precomputed Lua level. This is because `_.export_lua_table` expects that every non-array table uses only string keys.

## Proposed solution
A possible solution that I found to fix the issue is just to check if the type of the key is a number before saving it, and writing it as a different format. Tested this on The King's Dungeon (which doesn't have this issue), and on this [tutorial repository](https://github.com/SquidGodDev/MetroidvaniaTutorial) (which does have this issue).
```lua
-- Line 625
for key, value in pairs(entry) do
	if type(key) == "number" then
		file:write("["..tostring(key).."]=")
	else
		file:write("[\""..tostring(key).."\"]=")
	end
	_write_entry(value, key)
	file:write(",")
end
```
