### PR TITLE
adding support for level custom fields

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -261,8 +261,8 @@ function LDtk.load_level( level_name )
 		
 	-- load level's custom fields
 	for index, field_data in ipairs(level_data.fieldInstances) do
-		level.customData = {}
-		level.customData[ field_data.__identifier ] = field_data.__value
+		level.custom_data = {}
+		level.custom_data[ field_data.__identifier ] = field_data.__value
 	end
 
 	-- handle layers
@@ -426,7 +426,7 @@ function LDtk.get_entities( level_name, layer_name )
 end
 
 -- return a tilemap for the level
--- @layer_name is optional, if nil than will return the first layer with tiles
+-- @layer_name is optional, if nil then will return the first layer with tiles
 function LDtk.create_tilemap( level_name, layer_name )
 	local layer = _.get_tile_layer( level_name, layer_name )
 	if not layer then return end
@@ -454,13 +454,17 @@ end
 -- return the position and site of the level in the world
 -- always available, the level doesn't need to be loaded
 function LDtk.get_rect( level_name )
-	return _level_rects[level_name]
+	return _level_rects[ level_name ]
 end
 
 -- return custom data for the specified level 
--- LDtk.get_customData( "Level_0" )
-function LDtk.get_customData( level_name )
-	return _levels[level_name].customData 
+-- @field_name is optional, if nil then it will return all the fields as a table
+function LDtk.get_custom_data( level_name, field_name )
+	if field_name then
+		return _levels[ level_name ].custom_data[ field_name ]
+	end
+
+	return _levels[ level_name ].custom_data
 end
 
 -- return all the tileIDs tagged in LDtk with tileset_enum_value

--- a/LDtk.lua
+++ b/LDtk.lua
@@ -258,6 +258,12 @@ function LDtk.load_level( level_name )
 			table.insert( level.neighbours[ direction ], _level_names[ neighbour_data.levelIid ])
 		end
 	end
+		
+	-- load level's custom fields
+	for index, field_data in ipairs(level_data.fieldInstances) do
+		level.customData = {}
+		level.customData[ field_data.__identifier ] = field_data.__value
+	end
 
 	-- handle layers
 	level.layers = {}
@@ -449,6 +455,12 @@ end
 -- always available, the level doesn't need to be loaded
 function LDtk.get_rect( level_name )
 	return _level_rects[level_name]
+end
+
+-- return custom data for the specified level 
+-- LDtk.get_customData( "Level_0" )
+function LDtk.get_customData( level_name )
+	return _levels[level_name].customData 
 end
 
 -- return all the tileIDs tagged in LDtk with tileset_enum_value

--- a/LDtk.lua
+++ b/LDtk.lua
@@ -460,11 +460,21 @@ end
 -- return custom data for the specified level 
 -- @field_name is optional, if nil then it will return all the fields as a table
 function LDtk.get_custom_data( level_name, field_name )
-	if field_name then
-		return _levels[ level_name ].custom_data[ field_name ]
+	local level = _levels[ level_name ]
+	if not level then
+		return nil
 	end
 
-	return _levels[ level_name ].custom_data
+	local custom_data = level.custom_data
+	if not custom_data then
+		return nil
+	end
+
+	if field_name then
+		return custom_data[ field_name ]
+	end
+
+	return custom_data
 end
 
 -- return all the tileIDs tagged in LDtk with tileset_enum_value


### PR DESCRIPTION
this simple example will show how to print the text in the current level's custom field:

```lua
    -- load custom data for selected level:
    customData = LDtk.get_customData( level_name )
    if customData.greeting then 
        print(customData.greeting)
    else
        print("no custom greeting found for level", level_name)
    end
```

![CleanShot 2023-06-10 at 16 17 12@2x](https://github.com/NicMagnier/PlaydateLDtkImporter/assets/90380755/b32cc6e1-02ee-4858-ab79-f264aa55dfeb)


