### PR TITLE
add get_level_name

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -523,9 +523,9 @@ function LDtk.get_layers(level_name)
 	return level.layers
 end
 
--- return a layer name given a uid
-function LDtk.get_level_name(level_uid)
-	return _level_names[level_uid]
+-- return the name of a level bsed on their Strind IID
+function LDtk.get_level_name(levelIid)
+	return _level_names[levelIid]
 end
 
 -- Generate an image from a section of a tileset

--- a/LDtk.lua
+++ b/LDtk.lua
@@ -523,6 +523,10 @@ function LDtk.get_layers(level_name)
 	return level.layers
 end
 
+-- return a layer name given a uid
+function LDtk.get_level_name(level_uid)
+	return _level_names[level_uid]
+end
 
 -- Generate an image from a section of a tileset
 -- https://ldtk.io/json/#ldtk-TilesetRect


### PR DESCRIPTION
Entity references look like this:
```lua
{
        [entityIid] = 8abfd930-3b70-11ee-84af-b5e40234e3c8,
        [layerIid] = a3b53eb0-3b70-11ee-973c-cfcdb685ef3c,
        [levelIid] = a3b4f090-3b70-11ee-973c-d982a01398d8,
        [worldIid] = e555a9c0-1460-11ee-8c5d-c3e63b15dcb2,
}
```

This adds a function to translate `levelIid` into the text name for `load_level` (I'm using to to connect doors between levels)