### PR TITLE
Fix level custom data only keeping the last key

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -264,8 +264,8 @@ function LDtk.load_level( level_name )
 	end
 
 	-- load level's custom fields
+	level.custom_data = {}
 	for index, field_data in ipairs(level_data.fieldInstances) do
-		level.custom_data = {}
 		level.custom_data[ field_data.__identifier ] = field_data.__value
 	end
 


### PR DESCRIPTION
Previously, the loop reset `custom_data` to an empty table every iteration.