### PR TITLE
add support for up and down neighbours

### DIFF
--- a/LDtk.lua
+++ b/LDtk.lua
@@ -276,14 +276,14 @@ function LDtk.load_level( level_name )
 	local level = {}
 	_levels[ level_data.identifier ] = level
 
-	level.neighbours = { east = {}, west = {}, north = {}, south = {}}
-	local direction_table = { e = "east", w = "west", n = "north", s = "south" }
-	for index, neighbour_data in ipairs(level_data.__neighbours) do
-		local direction = direction_table[ neighbour_data.dir ]
-		if direction then
-			table.insert( level.neighbours[ direction ], _level_names[ neighbour_data.levelIid ])
-		end
-	end
+	level.neighbours = { east = {}, west = {}, north = {}, south = {}, up = {}, down = {} }
+    	local direction_table = { e = "east", w = "west", n = "north", s = "south", [">"] = "up", ["<"] = "down" }
+    	for index, neighbour_data in ipairs(level_data.__neighbours) do
+        	local direction = direction_table[neighbour_data.dir]
+       		if direction then
+           		table.insert(level.neighbours[direction], _level_names[neighbour_data.levelIid])
+        	end
+    	end
 
 	-- load level's custom fields
 	level.custom_data = {}
@@ -466,7 +466,7 @@ function LDtk.create_tilemap( level_name, layer_name )
 end
 
 -- return a table with all the adjacent levels
--- @direction is optional: values can be "east", "west", "north", "south"
+-- @direction is optional: values can be "east", "west", "north", "south", "up", "down"
 function LDtk.get_neighbours( level_name, direction )
 	local level = _levels[level_name]
 	if not level then return end


### PR DESCRIPTION
The current version of the get_neighbours function does not support levels on top and on the bottom.
In the LDtk JSON file, the directions are marked with < and >. So I altered the code for landing the level's neighbours.